### PR TITLE
FEATURE: Add tooltips for categories in minimized state

### DIFF
--- a/javascripts/discourse/widgets/layouts-category-list.js
+++ b/javascripts/discourse/widgets/layouts-category-list.js
@@ -343,11 +343,18 @@ createWidget('layouts-category-link', {
   },
 
   buildAttributes() {
-    const { category } = this.attrs;
-    return {
-      "aria-label": category.name,
-      title: category.name
-    };
+    const { category, sidebarMinimized } = this.attrs;
+
+    const attributes = {};
+
+    if (sidebarMinimized) {
+      attributes["data-tooltip"] = category.name;
+    }
+
+    attributes["aria-label"] = category.name;
+    attributes["title"] = category.name;
+
+    return attributes;
   },
 
   buildClasses(attrs, state) {


### PR DESCRIPTION
Tooltips appear with the category name on the icon when minimized (using Discourse native tooltip lib)

**Tooltips currently appear like this:**
<img width="118" alt="Screen Shot 2021-09-07 at 10 00 45 AM" src="https://user-images.githubusercontent.com/30090424/132383364-7e10ee35-0b7c-4aee-a0ba-629a977f104d.png">

It would be nice if they could be right aligned like this:
<img width="264" alt="Screen Shot 2021-09-07 at 10 04 28 AM" src="https://user-images.githubusercontent.com/30090424/132383776-ebab0ff0-f0de-451a-b9b3-8163e2acf4fa.png">

@angusmcleod: any idea on how we could add the 'is-right-aligned' (seen in `d-popover.js` (app/assets/javascripts/discourse/app/lib) ) to improve this tooltip? I think it needs to be applied to the tooltip element, but it seems theres no currently existing helpers/actions to do this.
