### PR TITLE
FEATURE: Toggle child category default appearance

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -265,13 +265,3 @@ aside.sidebar.full.tablet {
 .show-more {
   text-align: center;
 }
-
-.layouts-category-list.children-default-expanded ul.parent-categories {
-  li.layouts-category-link.showing-children,
-  .layouts-category-list
-    ul.parent-categories
-    li.layouts-category-link:hover:not(.no-link),
-  ul.child-categories {
-    background-color: transparent;
-  }
-}

--- a/common/common.scss
+++ b/common/common.scss
@@ -265,3 +265,13 @@ aside.sidebar.full.tablet {
 .show-more {
   text-align: center;
 }
+
+.layouts-category-list.children-default-expanded ul.parent-categories {
+  li.layouts-category-link.showing-children,
+  .layouts-category-list
+    ul.parent-categories
+    li.layouts-category-link:hover:not(.no-link),
+  ul.child-categories {
+    background-color: transparent;
+  }
+}

--- a/javascripts/discourse/initializers/layouts-category-list.js.es6
+++ b/javascripts/discourse/initializers/layouts-category-list.js.es6
@@ -36,9 +36,11 @@ export default {
     categories.forEach(function (c) {
       let parent = c.parentCategory;
       if (parent) {
-        let siblings = childCategories[parent.slug] || [];
-        siblings.push(c);
-        childCategories[parent.slug] = siblings;
+        if (!settings.hide_subcategories) {
+          let siblings = childCategories[parent.slug] || [];
+          siblings.push(c);
+          childCategories[parent.slug] = siblings;
+        }
       } else {
         parentCategories.push(c);
       }

--- a/javascripts/discourse/widgets/layouts-category-list.js
+++ b/javascripts/discourse/widgets/layouts-category-list.js
@@ -67,7 +67,6 @@ export default layouts.createLayoutsWidget('category-list', {
     const { childCategories } = this.attrs;
     if (!childCategories || !category || !childCategories[category.slug])
       return [];
-    if (settings.child_categories_default_state === 'hidden') return [];
 
     return this.filterExclusions(childCategories[category.slug]);
   },

--- a/javascripts/discourse/widgets/layouts-category-list.js
+++ b/javascripts/discourse/widgets/layouts-category-list.js
@@ -82,16 +82,6 @@ export default layouts.createLayoutsWidget('category-list', {
     return list.filter((c) => excluded.indexOf(c.slug) === -1);
   },
 
-  buildClasses(attrs) {
-    let classes = [];
-
-    if (settings.child_categories_default_state === 'expanded') {
-      classes.push('children-default-expanded');
-    }
-
-    return classes;
-  },
-
   html(attrs, state) {
     const { category, mobileView, tabletView } = attrs;
     const categories = this.getParents();

--- a/javascripts/discourse/widgets/layouts-category-list.js
+++ b/javascripts/discourse/widgets/layouts-category-list.js
@@ -67,6 +67,8 @@ export default layouts.createLayoutsWidget('category-list', {
     const { childCategories } = this.attrs;
     if (!childCategories || !category || !childCategories[category.slug])
       return [];
+    if (settings.child_categories_default_state === 'hidden') return [];
+
     return this.filterExclusions(childCategories[category.slug]);
   },
 

--- a/javascripts/discourse/widgets/layouts-category-list.js
+++ b/javascripts/discourse/widgets/layouts-category-list.js
@@ -83,6 +83,16 @@ export default layouts.createLayoutsWidget('category-list', {
     return list.filter((c) => excluded.indexOf(c.slug) === -1);
   },
 
+  buildClasses(attrs) {
+    let classes = [];
+
+    if (settings.child_categories_default_state === 'expanded') {
+      classes.push('children-default-expanded');
+    }
+
+    return classes;
+  },
+
   html(attrs, state) {
     const { category, mobileView, tabletView } = attrs;
     const categories = this.getParents();

--- a/javascripts/discourse/widgets/layouts-category-list.js
+++ b/javascripts/discourse/widgets/layouts-category-list.js
@@ -175,9 +175,9 @@ export default layouts.createLayoutsWidget('category-list', {
       this.isParentOfCurrent(category) ||
       this.isGrandparentOfCurrent(category);
     const hasChildren = children.length > 0;
-    const childrenAlwaysShown =
+    const childrenDefaultExpanded =
       settings.child_categories_default_state === 'expanded';
-    const shouldExpandChildren = current || childrenAlwaysShown;
+    const shouldExpandChildren = current || childrenDefaultExpanded;
     const showChildren =
       shouldExpandChildren && hasChildren && !hideChildren[category.id];
     const customLogos = this.customLogos();

--- a/javascripts/discourse/widgets/layouts-category-list.js
+++ b/javascripts/discourse/widgets/layouts-category-list.js
@@ -176,7 +176,11 @@ export default layouts.createLayoutsWidget('category-list', {
       this.isParentOfCurrent(category) ||
       this.isGrandparentOfCurrent(category);
     const hasChildren = children.length > 0;
-    const showChildren = current && hasChildren && !hideChildren[category.id];
+    const childrenAlwaysShown =
+      settings.child_categories_default_state === 'expanded';
+    const shouldExpandChildren = current || childrenAlwaysShown;
+    const showChildren =
+      shouldExpandChildren && hasChildren && !hideChildren[category.id];
     const customLogos = this.customLogos();
     const customLogoUrl = customLogos[category.slug];
 

--- a/settings.yml
+++ b/settings.yml
@@ -84,3 +84,12 @@ custom_headers:
         href (optional): valid href</br>
       Example: Teams,links:below,/teams adds the header "Teams" to the custom links that appear
       below the category list
+child_categories_default_state:
+  type: enum
+  default: collapsed
+  choices:
+    - collapsed
+    - expanded
+    - hidden
+  description:
+    en: The default state of child categories in the sidebar.

--- a/settings.yml
+++ b/settings.yml
@@ -3,6 +3,11 @@ excluded_categories:
   default: ''
   description:
     en: 'List of excluded category slugs'
+hide_subcategories:
+  type: bool
+  default: false
+  description:
+    en: 'If selected, all subcategories will not be shown in the sidebar'
 order_by_activity:
   type: list
   default: ''
@@ -90,6 +95,5 @@ child_categories_default_state:
   choices:
     - collapsed
     - expanded
-    - hidden
   description:
     en: The default state of child categories in the sidebar.


### PR DESCRIPTION
Toggle the default appearance of child categories. Select between:
- hidden
- collapsed (default)
- expanded

Hidden: hides all child categories always
Collapsed: collapses child categories and expands on click
Expanded: starts with child categories expanded and can be clicked to collapse

Created feature to fulfill feature request by Michael Downey:
https://thepavilion.io/t/category-list-widget-toggle-to-allow-fully-expanded-category-hierarchy/4464